### PR TITLE
Updated Version: account creation/ cookies/ overall structure

### DIFF
--- a/src/test/java/PageObjects/BasePage.java
+++ b/src/test/java/PageObjects/BasePage.java
@@ -3,7 +3,6 @@ package PageObjects;
 import io.restassured.RestAssured;
 import io.restassured.filter.cookie.CookieFilter;
 import io.restassured.http.ContentType;
-import io.restassured.http.Cookies;
 import io.restassured.path.xml.XmlPath;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
@@ -15,51 +14,43 @@ abstract class BasePage {
     String pageElement;
     RequestSpecification httpRequest;
     private static final String BASE_URL = "http://3.11.77.136/index.php";
+    static CookieFilter cookieFilter = new CookieFilter();
 
     public BasePage() {
         RestAssured.baseURI = BASE_URL;
-        httpRequest = RestAssured.given();
+        httpRequest = RestAssured.given().filter(cookieFilter);
+    }
 
+    public void assertStatusCode(int statusCode) {
+        Assertions.assertEquals(statusCode, getStatusCode());
     }
-    public void assertStatusCode(int statusCode){
-        Assertions.assertEquals(statusCode, response.getStatusCode());
-    }
-    public String getGpathFromXmlBody(String gPath){
+
+    public String getGpathFromXmlBody(String gPath) {
         XmlPath xmlPath = new XmlPath(XmlPath.CompatibilityMode.HTML, getResponseBody());
         return pageElement = xmlPath.get(gPath).toString();
     }
-//    "**.find {it.@class=='account'}.span"
-    CookieFilter cookieFilter = new CookieFilter();
 
-    public Response sendGetRequest(String url) {
-        response = RestAssured.given()
+    //    "**.find {it.@class=='account'}.span"
+
+    public Response sendGetRequest(String endpoint) {
+        response = httpRequest
                 .filter(cookieFilter)
                 .when()
-                .get(url)
+                .get(endpoint)
                 .then().contentType(ContentType.HTML)
                 .extract()
                 .response();
         return response;
-
     }
 
-    public void logResponseDetails() {
-        System.out.println("Status Code = " + getStatusCode());
-        System.out.println("Cookies = " + getCookies());
-    }
-
-    public Cookies getCookies() {
-        return response.getDetailedCookies();
-    }
+    //public Response sendPostRequest()
 
     public int getStatusCode() {
         return response.getStatusCode();
     }
 
     public String getResponseBody() {
-        sendGetRequest("");
         return response.getBody().asPrettyString();
     }
-
 
 }

--- a/src/test/java/PageObjects/CreateAccountPage.java
+++ b/src/test/java/PageObjects/CreateAccountPage.java
@@ -1,17 +1,14 @@
 package PageObjects;
 
-
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.jupiter.api.Assertions;
 import java.util.HashMap;
 import java.util.Map;
-
 
 public class CreateAccountPage extends BasePage {
 
     private String generateEmail = RandomStringUtils.randomAlphabetic(7);
 
-    public void createAcc() {
+    public void createNewAccount() {
         //Base URI defined in Base Page
         //Passing the resource details
 
@@ -30,9 +27,9 @@ public class CreateAccountPage extends BasePage {
                 .formParams(formData)
                 .post();
 
-        assertStatusCode(302);
-        getGpathFromXmlBody("**.find {it.@class=='account'}.span");
-        Assertions.assertEquals("Benjamin Button", pageElement);
+        /**
+         * 1) Make a reusable post method that takes in the formdata as a parameter
+         * */
 
     }
 }

--- a/src/test/java/PageObjects/HomePage.java
+++ b/src/test/java/PageObjects/HomePage.java
@@ -2,9 +2,11 @@ package PageObjects;
 
 public class HomePage extends BasePage{
 
-
     public void getHomePage() {
-        String url = "http://3.11.77.136/index.php";
-        response = sendGetRequest(url);
+        response = sendGetRequest("");
+    }
+
+    public String getLoggedInUsername (){
+        return getGpathFromXmlBody("**.find {it.@class=='account'}.span");
     }
 }

--- a/src/test/java/Tests/BaseTest.java
+++ b/src/test/java/Tests/BaseTest.java
@@ -1,21 +1,29 @@
 package Tests;
 
-import io.restassured.RestAssured;
-import io.restassured.http.Method;
-import io.restassured.response.Response;
-import io.restassured.specification.RequestSpecification;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 public class BaseTest {
 
-    @Test
-    public void GetRequest() {
-        RestAssured.baseURI = "http://3.11.77.136/index.php";
-        RequestSpecification httpRequest = RestAssured.given();
-        Response response = httpRequest.request(Method.GET, "");
-        System.out.println("Status received => " + response.getStatusLine());
-        System.out.println("Response=>" + response.prettyPrint());
+    @BeforeAll
+    static void beforeAll() {
+
     }
 
+    @BeforeEach
+    void beforeEach() {
 
+    }
+
+    @AfterEach
+    void afterEach() {
+
+    }
+
+    @AfterAll
+   static void afterAll() {
+
+    }
 }

--- a/src/test/java/Tests/CreateAccTest.java
+++ b/src/test/java/Tests/CreateAccTest.java
@@ -2,20 +2,30 @@ package Tests;
 
 import PageObjects.CreateAccountPage;
 import PageObjects.HomePage;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class CreateAccTest {
 
-    HomePage homePage = new HomePage();
-    CreateAccountPage createAccountPage = new CreateAccountPage();
+    HomePage homePage;
+    CreateAccountPage createAccountPage;
+
+    public CreateAccTest() {
+        createAccountPage = new CreateAccountPage();
+        homePage = new HomePage();
+    }
+
     @Test
-    public void Test2(){
+    public void getHomepageTest() {
         homePage.getHomePage();
         homePage.assertStatusCode(200);
     }
+
     @Test
-    public void createNewAcc(){
-        createAccountPage.createAcc();
-        createAccountPage.assertStatusCode(200);
+    public void createNewAccountTest() {
+        createAccountPage.createNewAccount();
+        Assertions.assertEquals(302, createAccountPage.getStatusCode());
+        homePage.getHomePage();
+        Assertions.assertEquals("Benjamin Button", homePage.getLoggedInUsername());
     }
 }


### PR DESCRIPTION
-Deleted logResponseDetails (No Usages)
- Base URI already exists --> no use for URL string, changed to endpoint

BaseTest:
- Deleted getRequest test, was not required
- Added Before/ After statements (empty)

CreateAccountPage:
- Utilised get status code and get Gpath body and moved assertions to the createNewAccountTest
- Renamed method 'createAcc' --> 'createNewAccount'

CreateAccTest:
- Added constructor initializing createAccountPage/ homePage
- createNewAccountTest --> added status code assertion/ page element assertion

HomePage:
- Altered getHomepage method --> removed redundant string
- Added method getLoggedInUsername --> returns username from Gpath