### PR TITLE
Added Test: Account creation as already registered user 

### DIFF
--- a/src/test/java/PageObjects/CreateAccountPage.java
+++ b/src/test/java/PageObjects/CreateAccountPage.java
@@ -7,9 +7,9 @@ import java.util.Map;
 
 public class CreateAccountPage extends BasePage {
 
-    String generateEmail = RandomStringUtils.randomAlphabetic(7);
+    private String generateEmail = RandomStringUtils.randomAlphabetic(7);
 
-    public void createNewAccount() {
+    public void createAccount() {
         Map<String, Object> formData = new HashMap<>();
         formData.put("id_gender", "1");
         formData.put("firstname", "Benjamin");
@@ -19,12 +19,31 @@ public class CreateAccountPage extends BasePage {
         formData.put("birthday", "12/06/1992");
         formData.put("submitCreate", 1);
 
-        Map <String, Object> queryParams = new HashMap<>();
+        Map<String, Object> queryParams = new HashMap<>();
         queryParams.put("controller", "authentication");
         queryParams.put("create_account", "1");
 
-        sendPostRequest("", formData, queryParams );
+        sendPostRequest("", formData, queryParams);
+    }
 
+    public void createAccountAsRegisteredUser() {
+        Map<String, Object> formData = new HashMap<>();
+        formData.put("id_gender", "1");
+        formData.put("firstname", "Benjamin");
+        formData.put("lastname", "Button");
+        formData.put("email", "Bbutton@test1.com");
+        formData.put("password", "wordpass");
+        formData.put("birthday", "12/06/1992");
+        formData.put("submitCreate", 1);
 
+        Map<String, Object> queryParams = new HashMap<>();
+        queryParams.put("controller", "authentication");
+        queryParams.put("create_account", "1");
+
+        sendPostRequest("", formData, queryParams);
+    }
+
+    public String getEmailAlreadyRegisteredAlert() {
+        return getGpathFromXmlBody("**.find {it.@class=='alert alert-danger'}");
     }
 }

--- a/src/test/java/Tests/CreateAccTest.java
+++ b/src/test/java/Tests/CreateAccTest.java
@@ -22,10 +22,20 @@ public class CreateAccTest {
     }
 
     @Test
-    public void createNewAccountTest() {
-        createAccountPage.createNewAccount();
+    public void createAccountTest() {
+        createAccountPage.createAccount();
         Assertions.assertEquals(302, createAccountPage.getStatusCode());
         homePage.getHomePage();
         Assertions.assertEquals("Benjamin Button", homePage.getLoggedInUsername());
+    }
+
+    @Test
+    public void createAccountAsRegisteredUserTest() {
+        createAccountPage.createAccountAsRegisteredUser();
+        Assertions.assertEquals("The email \"Bbutton@test1.com\" is already used, please choose another one or sign in",
+                createAccountPage.getEmailAlreadyRegisteredAlert());
+
+
+
     }
 }


### PR DESCRIPTION
CreateAccountPage;
- Added new method createAccountAsRegisteredUser
- Added new method getEmailAlreadyRegisteredAlert for assertion

CreateAccTest:
- Renamed createNewAccountTest to createAccountTest (for better readability/ conciseness)
- Added createAccountAsRegisteredUserTest which asserts if the alert 'The email "something@email" is already used' appears when attempting to register an already registered email